### PR TITLE
Replaced asString with array join

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,12 +42,13 @@ JedWebpackPlugin.prototype.apply = function(compiler) {
         // Add module to chunk
         chunk.addModule(jedModule);
 
+        var mainTemplate = compilation.mainTemplate;
         return [
           source,
           '',
           '// Jed Webpack Plugin',
-          'var Jed = ' + this.requireFn + '(' + jedModule.id + ')' + ';',
-          this.requireFn + '.jed = new Jed({ locale_data: ' + JSON.stringify(localeData) + ' });'
+          'var Jed = ' + mainTemplate.requireFn + '(' + jedModule.id + ')' + ';',
+          mainTemplate.requireFn + '.jed = new Jed({ locale_data: ' + JSON.stringify(localeData) + ' });'
         ].join("\n");
       }
       else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,13 +42,13 @@ JedWebpackPlugin.prototype.apply = function(compiler) {
         // Add module to chunk
         chunk.addModule(jedModule);
 
-        return this.asString([
+        return [
           source,
           '',
           '// Jed Webpack Plugin',
           'var Jed = ' + this.requireFn + '(' + jedModule.id + ')' + ';',
           this.requireFn + '.jed = new Jed({ locale_data: ' + JSON.stringify(localeData) + ' });'
-        ]);
+        ].join("\n");
       }
       else {
         return source;


### PR DESCRIPTION
This fix will resolve issue https://github.com/fakundo/jed-webpack-plugin/issues/2 . Using Webpack 4, this.asString is not available when calling 'require-extensions'. It has been replaced with a simple array join. This was favoured over importing the Template class since Webpack 3 and Webpack 4 both simply join the array with a newline.